### PR TITLE
original argmap fixes: argmap2mup and pandoc-argmap.lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/
+argmap.code-workspace
+Input/
+Output/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-.vscode/
 argmap.code-workspace
-Input/
-Output/
+.vscode/*
+!.vscode/launch.json
+!.vscode/settings.json
+archive
+lua_modules/
+Input/*
+Input/Archived/
+Output/*
+examples/*
+9bee0f80d302c53bc6ca6edbf3789ef438394fb8.png

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
-Copyright (c) 2019 David Sanson
+Changes in https://github.com/s6mike/argmap Copyright (c) 2022 Michael Hayes
+
+Original code in https://github.com/dsanson/argmap Copyright (c) 2019 David Sanson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 Argmap Project News
 ===================
 
-# argmap 1.0.2
-- Update NEWS to start from 1.0.1 to reflect dsanson's original repo
+# argmap 1.1.1
+- Updated my changes to start from 1.1.0 for continuity from dsanson's original repo.
 
-# argmap 1.0.1
+# argmap 1.1.0
 - Fork of https://github.com/dsanson/argmap
 - argmap2mup fix (potentially caused by different lua version):
     - Close #1 output file start with 'nil'
@@ -16,3 +16,5 @@ Argmap Project News
 Original https://github.com/dsanson/argmap
 
 Uses Semantic Versioning: http://semver.org/
+
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 Argmap Project News
 ===================
 
+# argmap 1.1.2
+- Update [README](README.markdown).
+
 # argmap 1.1.1
 - Updated my changes to start from 1.1.0 for continuity from dsanson's original repo.
 
@@ -10,11 +13,16 @@ Argmap Project News
     - Close #1 output file start with 'nil'
     - Close #2 gdrive upload fails
 - Update license and readme.
-- Add conda export: environment.yml, .gitignore and this NEWS.md file.
+- Add .gitignore, conda export: environment.yml
+
+# argmap 1.0.2
+- Update [README](README.markdown).
+
+# argmap 1.0.1
+- Update [README](README.markdown), [license](LICENSE).
+- Add this NEWS.md file.
 
 # argmap 1.0.0
 Original https://github.com/dsanson/argmap
 
-Uses Semantic Versioning: http://semver.org/
-
-
+Uses Semantic Versioning: http://semver.org/ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,12 @@
+Argmap Project News
+===================
+
+# argmap 0.0.1
+- Fork of https://github.com/dsanson/argmap
+- argmap2mup fix (potentially caused by different lua version):
+    - Close #1 starts file with nil
+    - Close #2 gdrive upload fails
+- Update license and readme.
+- Add conda export: environment.yml, .gitignore and this NEWS.md file.
+
+Uses Semantic Versioning: http://semver.org/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 Argmap Project News
 ===================
 
+# argmap 1.1.3
+- Update [README](README.markdown).
+
 # argmap 1.1.2
 - Update [README](README.markdown).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,18 @@
 Argmap Project News
 ===================
 
-# argmap 0.0.1
+# argmap 1.0.2
+- Update NEWS to start from 1.0.1 to reflect dsanson's original repo
+
+# argmap 1.0.1
 - Fork of https://github.com/dsanson/argmap
 - argmap2mup fix (potentially caused by different lua version):
-    - Close #1 starts file with nil
+    - Close #1 output file start with 'nil'
     - Close #2 gdrive upload fails
 - Update license and readme.
 - Add conda export: environment.yml, .gitignore and this NEWS.md file.
+
+# argmap 1.0.0
+Original https://github.com/dsanson/argmap
 
 Uses Semantic Versioning: http://semver.org/

--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,8 @@ See [NEWS.md](NEWS.md) for change notes.
 
 [![](examples/2cc90b7c54f340b9e4589f2c1b5a26589a5f2653.png)](https://drive.mindmup.com/map/18asUocP9fUtPbA8h4-qtTTfem0bxGunB)
 
+This project is not being actively maintained by me at the moment. If you are interested in it, you might consider Michael Hayes's fork: <https://github.com/s6mike/argmap>
+
 This repository contains some tools for working with argument maps written in
 a relatively simple [`YAML`](https://yaml.org/) format, described below. For
 example, the map above was generated from this `YAML`:

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,8 @@
 Argument Maps in YAML
 =====================
 
+See [NEWS.md](NEWS.md) for change notes.
+
 [![](examples/2cc90b7c54f340b9e4589f2c1b5a26589a5f2653.png)](https://drive.mindmup.com/map/18asUocP9fUtPbA8h4-qtTTfem0bxGunB)
 
 This repository contains some tools for working with argument maps written in
@@ -24,12 +26,17 @@ Mode](https://www.mindmup.com/tutorials/argument-visualization.html).
 Installation
 ------------
 
-Place `argmap2mup`, `argmap2tikz`, and `mup2argmap` somewhere in your path.
+Place `argmap2mup`, `argmap2tikz`, and `mup2argmap` somewhere in your path e.g. ~/bin.
+
 Place `pandoc-argmap.lua` in the `filters` folder inside your pandoc data
 directory, e.g., `$HOME/.pandoc/filters/pandoc-argmap.lua`.
 
 Dependencies
 ------------
+
+Lua: using Lua version 5.3.4
+
+See environment.yml for other dependencies and version numbers.
 
 `argmap2mup`, `argmap2tikz`, and `mup2argmap` require
 [penlight](https://github.com/stevedonovan/Penlight) (for command line option
@@ -632,6 +639,19 @@ generates individual pdf files for each map, and then converts them to png
 using ImageMagick's `convert` command. It replaces the code block with a
 paragraph containing the generated image, linked to the mindmup file.
 
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+
+# Fork details
+
+Fork of https://github.com/dsanson/argmap
+
+Installed with lua 5.3.4
+
+Fixed some issues (potentially caused by different lua version).
+
+
 TODO
 ----
 
@@ -652,4 +672,3 @@ TODO
 -   [x] mup2argmap should support fetching mup files from Google Drive and
     offer embeddable output (i.e., code block with both name and gid
     attributes)
-

--- a/README.markdown
+++ b/README.markdown
@@ -1,11 +1,17 @@
 Argument Maps in YAML
 =====================
 
-See [NEWS.md](NEWS.md) for change notes.
-
 [![](examples/2cc90b7c54f340b9e4589f2c1b5a26589a5f2653.png)](https://drive.mindmup.com/map/18asUocP9fUtPbA8h4-qtTTfem0bxGunB)
 
-This project is not being actively maintained by me at the moment. If you are interested in it, you might consider Michael Hayes's fork: <https://github.com/s6mike/argmap>
+This project is not being actively maintained by me at the moment. If you are interested in it, you might consider Michael Hayes's fork: https://github.com/s6mike/argmap.
+
+His fixes and improvements are on two branches:
+- argmap2mup-fix: fixes some issues in this file only, with corresponding documentation updates.
+- bugfixes: more fixes, plus much broader changes, including formatting, bash aliases etc.
+
+See relevant [NEWS.md](NEWS.md) for change notes.
+
+-------------
 
 This repository contains some tools for working with argument maps written in
 a relatively simple [`YAML`](https://yaml.org/) format, described below. For

--- a/README.markdown
+++ b/README.markdown
@@ -5,11 +5,7 @@ Argument Maps in YAML
 
 This project is not being actively maintained by me at the moment. If you are interested in it, you might consider Michael Hayes's fork: https://github.com/s6mike/argmap.
 
-His fixes and improvements are on two branches:
-- argmap2mup-fix: fixes some issues in this file only, with corresponding documentation updates.
-- bugfixes: more fixes, plus much broader changes, including formatting, bash aliases etc.
-
-See relevant [NEWS.md](NEWS.md) for change notes.
+Some of his fixes and improvements are on branches, see relevant [NEWS.md](NEWS.md) for change notes.
 
 -------------
 

--- a/argmap2mup
+++ b/argmap2mup
@@ -551,8 +551,8 @@ function parse_options(a)
 end
 
 function main()
-    print(args)
-    local opts = parse_options(args)
+    --print(args)
+    local opts = parse_options(arg)
     if opts["help"] then
         return help()
     else
@@ -569,7 +569,8 @@ function main()
         output["ideas"] = parse_claims(argmap)
         output["title"] = name
         local mup = json.encode(output)
-
+        
+        local folderopt = ""
         if opts["upload"] and opts["gdrive_id"] then
             pipe_in_out("gdrive update " .. 
                         "--no-progress " ..

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Argmap Project News
 ===================
 
+# argmap 1.1.4
+- Rename this file to docs/CHANGELOG.md
+- Refined conda install environment.
+
 # argmap 1.1.3
 - Update [README](README.markdown).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,35 +1,48 @@
 Argmap Project News
 ===================
 
+# argmap 1.1.5
+
+- `pandoc-argmap.lua`: Fix crashes for 2 [README.md](../README.md) md to pdf examples. Close s6mike/argmap#19.
+- Update `.gitignore`
+
 # argmap 1.1.4
+
 - Rename this file to docs/CHANGELOG.md
 - Refined conda install environment.
 
 # argmap 1.1.3
+
 - Update [README](README.markdown).
 
 # argmap 1.1.2
+
 - Update [README](README.markdown).
 
 # argmap 1.1.1
+
 - Updated my changes to start from 1.1.0 for continuity from dsanson's original repo.
 
 # argmap 1.1.0
-- Fork of https://github.com/dsanson/argmap
+
+- Fork of <https://github.com/dsanson/argmap>
 - argmap2mup fix (potentially caused by different lua version):
-    - Close #1 output file start with 'nil'
-    - Close #2 gdrive upload fails
+  - Close s6mike/argmap#1 output file start with 'nil'
+  - Close s6mike/argmap#2 gdrive upload fails
 - Update license and readme.
 - Add .gitignore, conda export: environment.yml
 
 # argmap 1.0.2
+
 - Update [README](README.markdown).
 
 # argmap 1.0.1
+
 - Update [README](README.markdown), [license](LICENSE).
 - Add this NEWS.md file.
 
 # argmap 1.0.0
-Original https://github.com/dsanson/argmap
 
-Uses Semantic Versioning: http://semver.org/ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+Original <https://github.com/dsanson/argmap>
+
+Uses Semantic Versioning: <http://semver.org/> and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,24 @@
+name: argmaps
+channels:
+  - anaconda-platform
+  - anaconda
+  - conda-forge
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=main
+  - _openmp_mutex=4.5=1_gnu
+  - ca-certificates=2022.4.26=h06a4308_0
+  - icu=68.1=h2531618_0
+  - libgcc-ng=9.3.0=h5101ec6_17
+  - libgomp=9.3.0=h5101ec6_17
+  - libstdcxx-ng=9.3.0=hd4cf53a_17
+  - libuv=1.40.0=h7b6447c_0
+  - lua=5.3.4=h7b6447c_0
+  - luarocks=3.7.0=lua53h06a4308_0
+  - ncurses=6.3=h7f8727e_2
+  - nodejs=16.13.1=hb931c9a_0
+  - openssl=1.1.1n=h7f8727e_0
+  - readline=7.0=h7b6447c_5
+  - unzip=6.0=0
+  - zlib=1.2.12=h7f8727e_2
+prefix: /opt/miniconda3/envs/argmaps

--- a/environment.yml
+++ b/environment.yml
@@ -1,24 +1,29 @@
 name: argmaps
 channels:
-  - anaconda-platform
   - anaconda
   - conda-forge
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
-  - _openmp_mutex=4.5=1_gnu
+  - _openmp_mutex=5.1=1_gnu
   - ca-certificates=2022.4.26=h06a4308_0
   - icu=68.1=h2531618_0
-  - libgcc-ng=9.3.0=h5101ec6_17
-  - libgomp=9.3.0=h5101ec6_17
-  - libstdcxx-ng=9.3.0=hd4cf53a_17
+  - libgcc-ng=11.2.0=h1234567_1
+  - libgomp=11.2.0=h1234567_1
+  - libstdcxx-ng=11.2.0=h1234567_1
   - libuv=1.40.0=h7b6447c_0
   - lua=5.3.4=h7b6447c_0
   - luarocks=3.7.0=lua53h06a4308_0
   - ncurses=6.3=h7f8727e_2
   - nodejs=16.13.1=hb931c9a_0
-  - openssl=1.1.1n=h7f8727e_0
+  - openssl=1.1.1o=h7f8727e_0
+  - pandoc=2.12=h06a4308_0
   - readline=7.0=h7b6447c_5
-  - unzip=6.0=0
+  - unzip=6.0=h7f98852_3
+  - yaml=0.2.5=h7b6447c_0
   - zlib=1.2.12=h7f8727e_2
+variables:
+  LUA_CPATH: /home/s6mike/git_projects/argmap/lua_modules/lib/lua/5.3/?.so;/opt/miniconda3/envs/argmaps/lib/lua/5.3/?.so;/opt/miniconda3/envs/argmaps/share/lua/5.3/lua_modules/lib/lua/5.3/?.so;/opt/miniconda3/envs/argmaps/lib/lua/5.3/loadall.so;./?.so;/home/s6mike/.luarocks/lib/lua/5.3/?.so
+  LUA_PATH: /home/s6mike/git_projects/argmap/lua_modules/share/lua/5.3/?.lua;/home/s6mike/git_projects/argmap/lua_modules/share/lua/5.3/?/init.lua;/opt/miniconda3/envs/argmaps/share/lua/5.3/?.lua;/opt/miniconda3/envs/argmaps/share/lua/5.3/?/init.lua;/opt/miniconda3/envs/argmaps/share/lua/5.3/lua_modules/share/lua/5.3/?.lua;/opt/miniconda3/envs/argmaps/share/lua/5.3/lua_modules/share/lua/5.3/?/init.lua;/opt/miniconda3/envs/argmaps/lib/lua/5.3/?.lua;/opt/miniconda3/envs/argmaps/lib/lua/5.3/?/init.lua;./?.lua;./?/init.lua;/home/s6mike/.luarocks/share/lua/5.3/?.lua;/home/s6mike/.luarocks/share/lua/5.3/?/init.lua
+  PATH: /home/s6mike/git_projects/argmap/lua_modules/bin:/home/s6mike/.luarocks/bin:/home/s6mike/bin:/opt/miniconda3/envs/argmaps/bin:/opt/miniconda3/condabin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
 prefix: /opt/miniconda3/envs/argmaps

--- a/pandoc-argmap.lua
+++ b/pandoc-argmap.lua
@@ -20,12 +20,12 @@ local function argmap2image(src, filetype, outfile)
     local o = nil
     local tmp = os.tmpname()
     local tmpdir = string.match(tmp, "^(.*[\\/])") or "."
-    local opts = "-s"
+    local opts = { "-s" }
     if format == "latex" or format == "beamer" then
         -- for any format other than raw tikz we need a standalone tex file
-        opts = ""
+        opts = {}
     end
-    local tex = pandoc.pipe("argmap2tikz",{opts}, src) -- convert map to standalone tex
+    local tex = pandoc.pipe("argmap2tikz", opts, src) -- convert map to standalone tex
     if format == 'latex' or format == 'beamer' then
         -- for latex, just return raw tex
         o = tex


### PR DESCRIPTION
Just broke my previous PR by renaming the branch, so here's a new PR from a new branch, same as before just with 1 extra fix for `pandoc-argmap.lua`.

Right now I don't plan to update this branch further or send any more PRs, but if you do want any additional fixes included in the future, please do let me know.

Original PR:

Mainly fixing 2 issues I had with argmap2mup not working. Possible that I'm using a different lua version to you (I'm using 5.3.4) and this has caused the issues.

There should be more fixes to follow since Mindmup still doesn't seem to like the uploaded GDrive files.

FYI this is my first ever pull request, and my first time using Lua, so apologies for any mistakes on my part. Feedback welcome!

argmap2mup fix (potentially caused by different lua version):
Close Issue 1 output file starts with 'nil'
Close Issue 2 gdrive upload fails
Update license and readme.
Add conda export: environment.yml, .gitignore and this NEWS.md file.